### PR TITLE
Choose single quotes by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -3204,12 +3204,12 @@ resource cleanup when possible.
 * <a name="consistent-string-literals"></a>
   Adopt a consistent string literal quoting style. There are two popular
   styles in the Ruby community, both of which are considered good - single
-  quotes by default (Option A) and double quotes by default (Option B).
+  quotes by default and double quotes by default. We are going to use single
+  quotes by default.
 <sup>[[link](#consistent-string-literals)]</sup>
 
-  * **(Option A)** Prefer single-quoted strings when you don't need
-    string interpolation or special symbols such as `\t`, `\n`, `'`,
-    etc.
+  * Prefer single-quoted strings when you don't need string interpolation or
+    special symbols such as `\t`, `\n`, `'`, etc.
 
     ```Ruby
     # bad
@@ -3218,19 +3218,6 @@ resource cleanup when possible.
     # good
     name = 'Bozhidar'
     ```
-
-  * **(Option B)** Prefer double-quotes unless your string literal
-    contains `"` or escape characters you want to suppress.
-
-    ```Ruby
-    # bad
-    name = 'Bozhidar'
-
-    # good
-    name = "Bozhidar"
-    ```
-
-  The string literals in this guide are aligned with the first style.
 
 * <a name="no-character-literals"></a>
   Don't use the character literal syntax `?x`. Since Ruby 1.9 it's basically


### PR DESCRIPTION
The guide mentioned the two options for string literals, single quotes
by default and double quotes by default.

We are going to use single quotes by default.
